### PR TITLE
Add Discord control panel UI and embeds

### DIFF
--- a/analysis/confluence_engine.py
+++ b/analysis/confluence_engine.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from binance.client import Client
+
+
+class ConfluenceEngine:
+    """Placeholder confluence engine aggregating analytical signals."""
+
+    def __init__(self, client: Client) -> None:
+        self.client = client
+        print("컨플루언스 엔진이 초기화되었습니다.")
+
+    async def build_snapshot(self) -> dict:
+        """Return a placeholder snapshot of analysis data."""
+        return {
+            "summary": "추세 강도: 중립",
+            "signals": [
+                {"symbol": "BTCUSDT", "confidence": 0.6, "direction": "LONG"},
+                {"symbol": "ETHUSDT", "confidence": 0.4, "direction": "SHORT"},
+            ],
+        }

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -25,7 +25,14 @@ class ConfigManager:
 
         # --- Discord ---
         self.discord_bot_token = os.getenv("DISCORD_BOT_TOKEN")
+        self.dashboard_channel_id = self._get_int("DISCORD_CHANNEL_ID_DASHBOARD")
         self.alerts_channel_id = self._get_int("DISCORD_CHANNEL_ID_ALERTS")
+        self.analysis_channel_id = self._get_int("DISCORD_CHANNEL_ID_ANALYSIS")
+        self.panel_channel_id = self._get_int("DISCORD_CHANNEL_ID_PANEL")
+
+        # --- Execution State ---
+        self.exec_active = self._get_bool("EXEC_ACTIVE", False)
+        self.aggr_level = self._get_int("AGGR_LEVEL", 1)
 
         # --- Analysis Timeframes & Weights ---
         self.timeframes = self._get_list("ANALYSIS_TIMEFRAMES")

--- a/execution/trading_engine.py
+++ b/execution/trading_engine.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import time
 from binance.client import Client
 
 from core.event_bus import event_bus
@@ -15,12 +18,16 @@ class TradingEngine:
         print(f"주문 실행 요청 수신: {symbol} {side} {quantity}")
         # Placeholder for real Binance order logic (Phase 2)
 
+        mock_order_id = int(time.time() * 1000)
         await event_bus.publish(
             "ORDER_SUCCESS",
             {
-                "symbol": symbol,
-                "side": side,
-                "quantity": quantity,
-                "price": 40000.0,  # Example price placeholder
+                "source": "TradingEngine",
+                "response": {
+                    "symbol": symbol,
+                    "side": side,
+                    "origQty": quantity,
+                    "orderId": mock_order_id,
+                },
             },
         )

--- a/main.py
+++ b/main.py
@@ -1,18 +1,24 @@
 import asyncio
+from datetime import datetime
+from typing import Optional
 
 import discord
 from binance.client import Client
+from discord import app_commands
 from discord.ext import commands, tasks
 
 from core.config_manager import config
 from core.event_bus import event_bus
-from database.manager import db_manager  # noqa: F401  # Ensures initialization
+from database.manager import db_manager  # noqa: F401 - ensure initialization side-effects
 from execution.trading_engine import TradingEngine
-
+from analysis.confluence_engine import ConfluenceEngine
+from risk_management.position_sizer import PositionSizer
+from ui.views import ControlPanelView
 
 intents = discord.Intents.default()
 intents.message_content = True
-bot = commands.Bot(command_prefix="/", intents=intents)
+bot = commands.Bot(command_prefix="!", intents=intents)
+tree = bot.tree
 
 
 def _create_binance_client() -> Client:
@@ -32,26 +38,97 @@ except Exception:
     exit()
 
 trading_engine = TradingEngine(binance_client)
+confluence_engine = ConfluenceEngine(binance_client)
+position_sizer = PositionSizer(binance_client)
+
+dashboard_message: Optional[discord.Message] = None
+
+
+def create_dashboard_embed() -> discord.Embed:
+    """실시간 대시보드 임베드를 생성합니다."""
+    embed = discord.Embed(title="📈 실시간 트레이딩 대시보드", color=discord.Color.blue())
+
+    system_status = "🟢 활성" if config.exec_active else "🔴 비활성"
+    pnl_today = "+$125.34 (+1.25%)"
+    total_equity = "$10,125.34"
+
+    embed.add_field(name="시스템 상태", value=system_status, inline=True)
+    embed.add_field(name="총 자산", value=total_equity, inline=True)
+    embed.add_field(name="금일 손익", value=pnl_today, inline=True)
+
+    btc_position = "LONG | 0.1 BTC @ $65,000\n> PnL: +$50.00 (+0.7%)"
+    eth_position = "없음"
+
+    embed.add_field(name="--- BTCUSDT 포지션 ---", value=btc_position, inline=False)
+    embed.add_field(name="--- ETHUSDT 포지션 ---", value=eth_position, inline=False)
+
+    embed.set_footer(text=f"마지막 업데이트: {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')} UTC")
+    return embed
+
+
+@tasks.loop(seconds=10)
+async def dashboard_update_loop() -> None:
+    """10초마다 대시보드를 업데이트합니다."""
+    global dashboard_message
+    channel = bot.get_channel(config.dashboard_channel_id)
+    if not channel:
+        if dashboard_update_loop.current_loop == 0:
+            print(f"경고: 대시보드 채널 ID({config.dashboard_channel_id})를 찾을 수 없습니다.")
+        return
+
+    embed = create_dashboard_embed()
+
+    if dashboard_message is None:
+        dashboard_message = await channel.send(embed=embed)
+    else:
+        try:
+            await dashboard_message.edit(embed=embed)
+        except discord.NotFound:
+            dashboard_message = await channel.send(embed=embed)
 
 
 @tasks.loop(seconds=1)
 async def event_listener() -> None:
-    """Listen for events from the event bus and dispatch Discord notifications."""
+    """이벤트 큐를 확인하고, 알림 임베드를 전송합니다."""
     try:
         event = await asyncio.wait_for(event_bus.subscribe(), timeout=1.0)
         channel = bot.get_channel(config.alerts_channel_id)
         if not channel:
-            print(f"경고: 알림 채널 ID({config.alerts_channel_id})를 찾을 수 없습니다.")
-            event_bus.task_done()
             return
 
-        if event["type"] == "ORDER_SUCCESS":
-            data = event["data"]
-            msg = (
-                "✅ **주문 체결 알림**\n"
-                f"> {data['side']} {data['symbol']} {data['quantity']} @ ${data['price']}"
+        event_type = event.get("type")
+        data = event.get("data", {})
+
+        if event_type == "ORDER_SUCCESS":
+            response = data.get("response", data)
+            source = data.get("source", "SYSTEM")
+            embed = discord.Embed(title="✅ 주문 체결 성공", color=discord.Color.green())
+            embed.add_field(name="출처", value=f"`{source}`", inline=False)
+            embed.add_field(name="심볼", value=response.get("symbol", "-"), inline=True)
+            embed.add_field(name="방향", value=response.get("side", "-"), inline=True)
+            embed.add_field(name="수량", value=str(response.get("origQty", response.get("quantity", "-"))), inline=True)
+            if "orderId" in response:
+                embed.set_footer(text=f"바이낸스 ID: {response['orderId']}")
+            await channel.send(embed=embed)
+
+        elif event_type == "ORDER_FAILURE":
+            params = data.get("params", {})
+            source = data.get("source", "SYSTEM")
+            embed = discord.Embed(title="❌ 주문 체결 실패", color=discord.Color.red())
+            embed.add_field(name="출처", value=f"`{source}`", inline=False)
+            embed.add_field(
+                name="요청 내용",
+                value=f"{params.get('side', '-') } {params.get('symbol', '-') } {params.get('quantity', '-')}",
+                inline=False,
             )
-            await channel.send(msg)
+            embed.add_field(name="오류 메시지", value=f"```{data.get('error', 'Unknown error')}```", inline=False)
+            await channel.send(embed=embed)
+
+        elif event_type == "PANIC_SIGNAL":
+            user = data.get("user", "알 수 없음")
+            embed = discord.Embed(title="🚨 긴급 청산 요청", color=discord.Color.orange())
+            embed.description = f"{user} 님이 긴급 청산을 요청했습니다."
+            await channel.send(embed=embed)
 
         event_bus.task_done()
     except asyncio.TimeoutError:
@@ -60,17 +137,65 @@ async def event_listener() -> None:
         print(f"이벤트 리스너 오류: {exc}")
 
 
+@tasks.loop(minutes=5)
+async def analysis_loop() -> None:
+    """주기적으로 분석 스냅샷을 게시합니다."""
+    channel = bot.get_channel(config.analysis_channel_id)
+    if not channel:
+        if analysis_loop.current_loop == 0:
+            print(f"경고: 분석 채널 ID({config.analysis_channel_id})를 찾을 수 없습니다.")
+        return
+
+    snapshot = await confluence_engine.build_snapshot()
+    embed = discord.Embed(title="🧠 컨플루언스 리포트", color=discord.Color.purple())
+    embed.add_field(name="요약", value=snapshot.get("summary", "데이터 없음"), inline=False)
+
+    signals = snapshot.get("signals", [])
+    if signals:
+        formatted_lines = []
+        for item in signals:
+            symbol = item.get("symbol", "-")
+            confidence = float(item.get("confidence", 0))
+            direction = item.get("direction", "-")
+            suggested = position_sizer.recommend_size(symbol, confidence)
+            formatted_lines.append(
+                f"• {symbol}: {direction} (신뢰도 {confidence:.0%}, 추천 수량 {suggested})"
+            )
+        formatted = "\n".join(formatted_lines)
+    else:
+        formatted = "신호가 없습니다."
+    embed.add_field(name="시그널", value=formatted, inline=False)
+
+    embed.set_footer(text=f"업데이트: {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')} UTC")
+    await channel.send(embed=embed)
+
+
 @bot.event
-async def on_ready():
-    print(f"{bot.user.name} 봇이 준비되었습니다.")
+async def on_ready() -> None:
+    bot.add_view(ControlPanelView())
+    await tree.sync()
+    print(f"{bot.user.name} 봇이 준비되었습니다. 슬래시 명령어가 동기화되었습니다.")
     print("------------------------------------")
     event_listener.start()
+    analysis_loop.start()
+    dashboard_update_loop.start()
 
 
-@bot.command(name="test_order")
-async def test_order(ctx: commands.Context) -> None:
-    """Trigger a simulated order to validate the event flow."""
-    await ctx.send("테스트 주문 실행을 요청합니다...")
+@tree.command(name="panel", description="시스템 제어 패널을 소환합니다.")
+@app_commands.checks.is_owner()
+async def summon_panel(interaction: discord.Interaction) -> None:
+    embed = discord.Embed(
+        title="⚙️ 시스템 제어 패널",
+        description="아래 버튼과 메뉴를 사용하여 시스템을 제어하세요.",
+        color=discord.Color.dark_gold(),
+    )
+    await interaction.response.send_message(embed=embed, view=ControlPanelView())
+
+
+@tree.command(name="test_order", description="테스트 주문을 실행하여 이벤트 흐름을 확인합니다.")
+@app_commands.checks.is_owner()
+async def test_order_slash(interaction: discord.Interaction) -> None:
+    await interaction.response.send_message("테스트 주문 실행을 요청합니다...", ephemeral=True)
     await trading_engine.place_order("BTCUSDT", "BUY", 0.01)
 
 

--- a/risk_management/position_sizer.py
+++ b/risk_management/position_sizer.py
@@ -1,0 +1,14 @@
+from binance.client import Client
+
+
+class PositionSizer:
+    """Placeholder position sizing utility."""
+
+    def __init__(self, client: Client) -> None:
+        self.client = client
+        print("포지션 사이저가 초기화되었습니다.")
+
+    def recommend_size(self, symbol: str, confidence: float) -> float:
+        """Return a naive position size recommendation based on confidence."""
+        base_size = 0.01
+        return round(base_size * max(confidence, 0.1), 4)

--- a/ui/views.py
+++ b/ui/views.py
@@ -1,0 +1,90 @@
+import discord
+
+from core.config_manager import config
+from core.event_bus import event_bus
+
+
+AGGRESSION_OPTIONS = [
+    discord.SelectOption(
+        label="레벨 1 - 보수적",
+        value="1",
+        description="최소한의 리스크를 감수하는 전략"
+    ),
+    discord.SelectOption(
+        label="레벨 2 - 균형형",
+        value="2",
+        description="리스크와 수익의 균형을 추구"
+    ),
+    discord.SelectOption(
+        label="레벨 3 - 적극적",
+        value="3",
+        description="더 큰 수익을 위해 리스크 허용"
+    ),
+    discord.SelectOption(
+        label="레벨 4 - 공격적",
+        value="4",
+        description="높은 리스크를 감수하는 전략"
+    ),
+    discord.SelectOption(
+        label="레벨 5 - 최대",
+        value="5",
+        description="극단적인 리스크를 감수하는 전략"
+    ),
+]
+
+
+class ControlPanelView(discord.ui.View):
+    """제어 패널의 버튼과 메뉴들을 포함하는 View 클래스입니다."""
+
+    def __init__(self) -> None:
+        super().__init__(timeout=None)
+
+    @discord.ui.button(
+        label="자동매매 시작",
+        style=discord.ButtonStyle.green,
+        custom_id="toggle_autotrade_start",
+    )
+    async def start_button(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        config.exec_active = True
+        await interaction.response.send_message("✅ 자동매매를 시작합니다.", ephemeral=True)
+        print("사용자가 자동매매 시작 버튼을 눌렀습니다.")
+
+    @discord.ui.button(
+        label="자동매매 중지",
+        style=discord.ButtonStyle.red,
+        custom_id="toggle_autotrade_stop",
+    )
+    async def stop_button(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        config.exec_active = False
+        await interaction.response.send_message("🛑 자동매매를 중지합니다.", ephemeral=True)
+        print("사용자가 자동매매 중지 버튼을 눌렀습니다.")
+
+    @discord.ui.button(
+        label="긴급 전체 청산",
+        style=discord.ButtonStyle.danger,
+        emoji="🚨",
+        custom_id="panic_close_all",
+    )
+    async def panic_button(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        await interaction.response.send_message(
+            "🚨 긴급 전체 청산 신호를 보냈습니다. 결과를 확인해주세요.",
+            ephemeral=True,
+        )
+        await event_bus.publish("PANIC_SIGNAL", {"user": interaction.user.name})
+
+    @discord.ui.select(
+        placeholder="투자 공격성 레벨 선택",
+        options=AGGRESSION_OPTIONS,
+        custom_id="select_agg_level",
+    )
+    async def agg_level_select(self, interaction: discord.Interaction, select: discord.ui.Select) -> None:
+        selected_level = select.values[0] if select.values else "1"
+        try:
+            config.aggr_level = int(selected_level)
+        except ValueError:
+            pass
+        await interaction.response.send_message(
+            f"투자 공격성 레벨을 **{selected_level}** (으)로 설정했습니다.",
+            ephemeral=True,
+        )
+        print(f"사용자가 공격성 레벨을 {selected_level}(으)로 변경했습니다.")


### PR DESCRIPTION
## Summary
- create a reusable Discord control panel view with buttons and an aggression selector
- refactor the bot to use slash commands, embeds, and background updates for dashboards and alerts
- add placeholder analysis and risk helpers plus configuration for the new Discord channels

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dc9346bb80832daba7e38f1af4f92a