### PR TITLE
Enable live Binance execution and dynamic sizing

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -48,6 +48,10 @@ class ConfigManager:
         self.open_threshold = self._get_float("OPEN_TH", 10.0)
         self.trade_quantity = self._get_float("TRADE_QUANTITY", 0.001)
 
+        # --- Risk Management ---
+        self.risk_target_pct = self._get_float("RISK_TARGET_PCT", 0.02)
+        self.sl_atr_multiplier = self._get_float("SL_ATR", 1.5)
+
 
 
         # --- Database ---

--- a/database/models.py
+++ b/database/models.py
@@ -29,6 +29,7 @@ class Trade(Base):
 
     id = Column(Integer, primary_key=True)
     signal_id = Column(Integer, ForeignKey("signals.id"))
+    binance_order_id = Column(String)
     symbol = Column(String)
     side = Column(String)
     quantity = Column(Float)

--- a/execution/trading_engine.py
+++ b/execution/trading_engine.py
@@ -1,6 +1,7 @@
-from __future__ import annotations
+from typing import Optional
 
 from binance.client import Client
+from binance.exceptions import BinanceAPIException
 
 from core.event_bus import event_bus
 from database.manager import db_manager
@@ -8,20 +9,27 @@ from database.models import Signal, Trade
 
 
 class TradingEngine:
-    """Skeleton trading engine responsible for handling order requests."""
+    """
+    거래 실행의 모든 로직을 담당하는 클래스.
+    실제 바이낸스 API와 연동하여 주문을 처리합니다.
+    """
 
-    def __init__(self, client: Client) -> None:
+    def __init__(self, client: Client):
         self.client = client
         print("트레이딩 엔진이 초기화되었습니다.")
 
     async def place_order(
         self, symbol: str, side: str, quantity: float, analysis_context: dict
     ) -> None:
-        """Simulate order execution and emit success events."""
+        """
+        분석 컨텍스트를 기록하고, 실제 바이낸스 주문을 생성한 후, 결과를 처리합니다.
+        """
         print(f"주문 실행 요청 수신: {symbol} {side} {quantity}")
 
         session = db_manager.get_session()
+        new_signal: Optional[Signal] = None
         try:
+            # 1. 분석 컨텍스트(신호)를 데이터베이스에 기록
             new_signal = Signal(
                 symbol=symbol,
                 final_score=analysis_context.get("final_score"),
@@ -31,37 +39,73 @@ class TradingEngine:
                 score_15m=analysis_context.get("tf_scores", {}).get("15m"),
             )
             session.add(new_signal)
-            session.commit()
+            session.commit()  # 신호 ID를 확정하기 위해 먼저 커밋
 
-            entry_price = 66000.0
+            if quantity is None or quantity <= 0:
+                raise ValueError("주문 수량이 유효하지 않습니다.")
 
+            # 2. 실제 바이낸스 주문 생성
+            # newOrderRespType='RESULT'로 설정하여 상세한 체결 정보를 받습니다.
+            order_params = {
+                "symbol": symbol,
+                "side": side,
+                "type": "MARKET",
+                "quantity": quantity,
+                "newOrderRespType": "RESULT",
+            }
+            binance_order = self.client.futures_create_order(**order_params)
+
+            # 3. 성공한 주문 결과를 DB에 기록
+            avg_price = binance_order.get("avgPrice") or binance_order.get("price")
+            entry_price = float(avg_price) if avg_price not in (None, "") else 0.0
             new_trade = Trade(
                 signal_id=new_signal.id,
-                symbol=symbol,
-                side=side,
-                quantity=quantity,
+                binance_order_id=binance_order.get("orderId"),
+                symbol=binance_order.get("symbol"),
+                side=binance_order.get("side"),
+                quantity=float(binance_order.get("origQty", quantity)),
                 entry_price=entry_price,
-                status="OPEN",
+                status=binance_order.get("status", "FILLED"),
             )
             session.add(new_trade)
             session.commit()
 
+            # 4. 성공 이벤트를 발행
             await event_bus.publish(
                 "ORDER_SUCCESS",
                 {
-                    "symbol": symbol,
-                    "side": side,
-                    "quantity": quantity,
-                    "price": entry_price,
+                    "symbol": new_trade.symbol,
+                    "side": new_trade.side,
+                    "quantity": new_trade.quantity,
+                    "price": new_trade.entry_price,
                     "source": "ConfluenceEngine",
+                    "response": binance_order,
                 },
             )
-        except Exception as exc:  # pragma: no cover - defensive logging
+
+        except BinanceAPIException as exc:
             session.rollback()
-            print(f"주문 처리 중 DB 오류 발생: {exc}")
+            print(f"주문 실패 (API 오류): {exc}")
+            if new_signal is not None:
+                failed_trade = Trade(
+                    signal_id=new_signal.id,
+                    symbol=symbol,
+                    side=side,
+                    quantity=quantity,
+                    status="REJECTED",
+                    pnl=0,
+                )
+                session.add(failed_trade)
+                session.commit()
             await event_bus.publish(
-                "ORDER_FAILURE",
-                {"error": str(exc), "source": "TradingEngine"},
+                "ORDER_FAILURE", {"error": str(exc), "source": "TradingEngine"}
+            )
+
+        except Exception as exc:
+            session.rollback()
+            print(f"주문 처리 중 오류 발생: {exc}")
+            await event_bus.publish(
+                "ORDER_FAILURE", {"error": str(exc), "source": "TradingEngine"}
             )
         finally:
             session.close()

--- a/risk_management/position_sizer.py
+++ b/risk_management/position_sizer.py
@@ -1,10 +1,9 @@
-# 파일명: risk_management/position_sizer.py (최종본)
-
 """Risk management helper for determining order quantities."""
 
-from __future__ import annotations
+from typing import Optional
 
 from binance.client import Client
+from binance.exceptions import BinanceAPIException
 
 from core.config_manager import config
 
@@ -14,17 +13,79 @@ class PositionSizer:
         self.client = client
         print("포지션 사이저가 초기화되었습니다.")
 
-    def calculate_position_size(self, symbol: str, entry_price: float, atr: float) -> float:
-        """
-        리스크 설정에 기반하여 적절한 포지션 크기(수량)를 계산합니다.
-        
-        Phase 2에서는.env에 설정된 고정 수량을 사용합니다.
-        향후 Phase에서는 ATR과 계좌 잔고를 이용한 동적 수량 계산 로직으로 발전될 것입니다.
-        """
-        
-        # TODO: ATR과 계좌 잔고를 이용한 동적 수량 계산 로직 구현
-        # 예: max_risk = account_balance * risk_per_trade_pct
-        #     stop_loss_distance = atr * atr_multiplier
-        #     quantity = max_risk / stop_loss_distance
+    def _get_usdt_balance(self) -> float:
+        """바이낸스 선물 계좌의 USDT 잔고를 조회합니다."""
+        try:
+            account_info = self.client.futures_account_balance()
+            for asset in account_info:
+                if asset.get("asset") == "USDT":
+                    return float(asset.get("balance", 0))
+            return 0.0
+        except BinanceAPIException as exc:
+            print(f"계좌 잔고 조회 실패: {exc}")
+            return 0.0
+        except Exception as exc:
+            print(f"계좌 잔고 조회 중 알 수 없는 오류: {exc}")
+            return 0.0
 
-        return config._get_float('TRADE_QUANTITY', 0.001)
+    def _get_mark_price(self, symbol: str) -> Optional[float]:
+        try:
+            mark_price = self.client.futures_mark_price(symbol=symbol)
+            return float(mark_price.get("markPrice"))
+        except BinanceAPIException as exc:
+            print(f"마크 가격 조회 실패: {exc}")
+        except Exception as exc:
+            print(f"마크 가격 조회 중 알 수 없는 오류: {exc}")
+        return None
+
+    def calculate_position_size(
+        self, symbol: str, entry_price: float, atr: float
+    ) -> Optional[float]:
+        """
+        리스크 설정에 기반하여 동적으로 포지션 크기(수량)를 계산합니다.
+
+        :return: 계산된 주문 수량 또는 계산 불가 시 None
+        """
+        account_balance = self._get_usdt_balance()
+        if account_balance <= 0:
+            print("계산 불가: 잔고가 0 이하입니다.")
+            return None
+
+        if atr is None or atr <= 0:
+            print("계산 불가: ATR이 0 이하입니다.")
+            return None
+
+        max_risk_per_trade = account_balance * config.risk_target_pct
+        stop_loss_distance = atr * config.sl_atr_multiplier
+
+        price = entry_price
+        if price is None or price <= 0:
+            mark_price = self._get_mark_price(symbol)
+            if mark_price is None or mark_price <= 0:
+                print(f"가격 조회 실패로 수량 계산 불가: {symbol}")
+                return None
+            price = mark_price
+
+        if stop_loss_distance <= 0:
+            print("계산 불가: 손절매 거리가 0 이하입니다.")
+            return None
+
+        quantity = max_risk_per_trade / stop_loss_distance
+
+        if quantity <= 0:
+            print("계산 불가: 계산된 수량이 0 이하입니다.")
+            return None
+
+        precision = 3
+        rounded_quantity = round(quantity, precision)
+
+        if rounded_quantity <= 0:
+            print("계산 불가: 반올림된 수량이 0 이하입니다.")
+            return None
+
+        print(
+            "동적 수량 계산: 잔고=${:,.2f}, 리스크=${:,.2f}, ATR=${:,.2f}, 가격=${:,.2f} -> 수량={}".format(
+                account_balance, max_risk_per_trade, atr, price, rounded_quantity
+            )
+        )
+        return rounded_quantity


### PR DESCRIPTION
## Summary
- wire the trading engine to submit real Binance Futures market orders and persist returned fills with order identifiers while broadcasting success or failure
- expose risk configuration for ATR-based sizing and extend the trade model schema to capture Binance order ids
- implement balance/ATR-aware position sizing and show live account balances and positions on the Discord dashboard with improved status messaging

## Testing
- python -m compileall execution/trading_engine.py risk_management/position_sizer.py main.py database/models.py
- python -m compileall execution/trading_engine.py
- python -m compileall risk_management/position_sizer.py

------
https://chatgpt.com/codex/tasks/task_e_68dcc19cbae8832daf786103505e2c93