### PR TITLE
Enhance dashboard embed and multi-symbol analysis

### DIFF
--- a/analysis/data_fetcher.py
+++ b/analysis/data_fetcher.py
@@ -1,34 +1,14 @@
-"""Utilities for retrieving market data from Binance."""
-
-from __future__ import annotations
-
-from typing import Optional
-
-import pandas as pd
 from binance.client import Client
+import pandas as pd
 
 
-_KLINE_COLUMNS = [
-    "timestamp",
-    "open",
-    "high",
-    "low",
-    "close",
-    "volume",
-    "close_time",
-    "quote_asset_volume",
-    "number_of_trades",
-    "taker_buy_base_asset_volume",
-    "taker_buy_quote_asset_volume",
-    "ignore",
-]
-
-
-def fetch_klines(client: Client, symbol: str, timeframe: str, limit: int = 1000) -> pd.DataFrame | None: # limit 기본값 변경
+def fetch_klines(client: Client, symbol: str, timeframe: str, limit: int = 1000) -> pd.DataFrame | None:  # limit 기본값 변경
     """
     바이낸스에서 K-line(캔들) 데이터를 가져와 pandas DataFrame으로 변환합니다.
     """
     try:
+        # testnet 모드 여부와 상관없이, 분석 데이터는 항상 실서버(fapi)에서 가져옵니다.
+        # python-binance 라이브러리는 Client 초기화 시 testnet=True여도 klines 조회는 실서버를 바라봅니다.
         klines = client.futures_klines(symbol=symbol, interval=timeframe, limit=limit)
         if not klines:
             return None
@@ -39,10 +19,9 @@ def fetch_klines(client: Client, symbol: str, timeframe: str, limit: int = 1000)
             'taker_buy_base_asset_volume', 'taker_buy_quote_asset_volume', 'ignore'
         ])
 
-        # 데이터 타입 변환
         df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms')
         df.set_index('timestamp', inplace=True)
-        
+
         for col in ['open', 'high', 'low', 'close', 'volume']:
             df[col] = pd.to_numeric(df[col])
 


### PR DESCRIPTION
## Summary
- refresh the dashboard embed with real account metrics, position details, and improved error handling
- expand futures kline retrieval and sanitize indicator outputs for reliable calculations
- analyze all configured symbols and trade the strongest signal instead of BTC-only

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcc870cfb0832dac3875158ab644c8