### PR TITLE
Enhance signal quality filters and trailing stop management

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -22,9 +22,13 @@ class ConfigManager:
             self.api_secret = os.getenv("BINANCE_LIVE_API_SECRET")
 
         # Analysis Engine
-        self.analysis_timeframes = self._get_list("ANALYSIS_TIMEFRAMES", ["1d", "4h", "1h", "15m"])
-        self.tf_vote_weights = self._get_list_float("TF_VOTE_WEIGHTS", [4.0, 3.0, 2.0, 1.0])
-        self.open_th = self._get_float("OPEN_TH", 12.0)
+        self.timeframes = self._get_list("ANALYSIS_TIMEFRAMES", ["15m", "1h", "4h", "1d"])
+        self.tf_vote_weights = self._get_list_float("TF_VOTE_WEIGHTS", [1.0, 2.0, 3.0, 4.0])
+        self.open_threshold = self._get_float("OPEN_TH", 10.0)
+
+        # Signal Quality Rules
+        self.quality_min_avg_score = self._get_float("QUALITY_MIN_AVG_SCORE", 15.0)
+        self.quality_max_std_dev = self._get_float("QUALITY_MAX_STD_DEV", 3.0)
 
         # Trading Logic Rules
         self.entry_confirm_count = self._get_int("ENTRY_CONFIRM_COUNT", 3)
@@ -35,6 +39,7 @@ class ConfigManager:
         self.risk_target_pct = self._get_float("RISK_TARGET_PCT", 0.02)
         self.sl_atr_multiplier = self._get_float("SL_ATR_MULTIPLIER", 1.5)
         self.take_profit_pct = self._get_float("TAKE_PROFIT_PCT", 0.05)
+        self.trailing_stop_enabled = self._get_bool("TRAILING_STOP_ENABLED", True)
 
         # Leverage Map
         self.leverage_map = {

--- a/database/models.py
+++ b/database/models.py
@@ -27,6 +27,7 @@ class Trade(Base):
     side = Column(String)
     quantity = Column(Float)
     entry_price = Column(Float)
+    highest_price_since_entry = Column(Float)
     exit_price = Column(Float)
     pnl = Column(Float)
     entry_time = Column(DateTime, default=datetime.utcnow)

--- a/main.py
+++ b/main.py
@@ -110,51 +110,127 @@ async def trading_decision_loop():
         open_trade = session.execute(select(Trade).where(Trade.status == "OPEN")).scalar_one_or_none()
 
         if open_trade:
-            # 포지션 관리 로직
-            current_price = float(binance_client.futures_mark_price(symbol=open_trade.symbol)['markPrice'])
-            pnl_pct = (current_price / open_trade.entry_price - 1) if open_trade.side == "BUY" else (1 - current_price / open_trade.entry_price)
+            # --- B. 포지션이 있을 경우 (청산 결정) ---
+            print(f"오픈된 포지션 관리 중: {open_trade.symbol} {open_trade.side}")
+            current_price_info = binance_client.futures_mark_price(symbol=open_trade.symbol)
+            current_price = float(current_price_info['markPrice'])
 
-            # 1. 익절
+            # 1. 진입 후 최고가/최저가 업데이트
+            if config.trailing_stop_enabled and open_trade.entry_atr:
+                if open_trade.side == "BUY" and (open_trade.highest_price_since_entry is None or current_price > open_trade.highest_price_since_entry):
+                    open_trade.highest_price_since_entry = current_price
+                    session.commit()
+                    print(f"📈 최고가 갱신: ${current_price}")
+                elif open_trade.side == "SELL" and (open_trade.highest_price_since_entry is None or current_price < open_trade.highest_price_since_entry):
+                    open_trade.highest_price_since_entry = current_price
+                    session.commit()
+                    print(f"📉 최저가 갱신: ${current_price}")
+
+                # 2. 동적 트레일링 스탑 라인 계산
+                if open_trade.side == "BUY":
+                    trailing_stop_price = open_trade.highest_price_since_entry - (open_trade.entry_atr * config.sl_atr_multiplier)
+                    if current_price < trailing_stop_price:
+                        await trading_engine.close_position(open_trade, f"트레일링 스탑 (TS: ${trailing_stop_price:.2f})")
+                        return
+                else:
+                    trailing_stop_price = open_trade.highest_price_since_entry + (open_trade.entry_atr * config.sl_atr_multiplier)
+                    if current_price > trailing_stop_price:
+                        await trading_engine.close_position(open_trade, f"트레일링 스탑 (TS: ${trailing_stop_price:.2f})")
+                        return
+
+            # 보조적 익절 로직 유지
+            pnl_pct = (current_price - open_trade.entry_price) / open_trade.entry_price if open_trade.side == "BUY" else (open_trade.entry_price - current_price) / open_trade.entry_price
             if pnl_pct >= config.take_profit_pct:
                 await trading_engine.close_position(open_trade, f"수익 실현 ({pnl_pct:+.2%})")
                 return
 
-            # 2. 기술적 손절 (ATR 기반)
-            sl_price = (open_trade.entry_price - open_trade.entry_atr * config.sl_atr_multiplier) if open_trade.side == "BUY" else (open_trade.entry_price + open_trade.entry_atr * config.sl_atr_multiplier)
-            if (open_trade.side == "BUY" and current_price <= sl_price) or \
-               (open_trade.side == "SELL" and current_price >= sl_price):
-                await trading_engine.close_position(open_trade, f"ATR 손절 (SL: {sl_price})")
-                return
-            
-            # ... (추세 반전 청산 로직은 이전과 동일하게 유지)
+            # ... (추세 반전 로직은 기존과 동일)
 
         else:
-            # 신규 진입 로직
+            # --- A. 포지션이 없을 경우 (신규 진입 결정) ---
+            print("신규 진입 기회 탐색 중...")
             for symbol in config.symbols:
-                recent_signals = session.execute(select(Signal).where(Signal.symbol == symbol).order_by(Signal.id.desc()).limit(config.entry_confirm_count)).scalars().all()
-                if len(recent_signals) < config.entry_confirm_count: continue
+                lookback_time = datetime.utcnow() - timedelta(minutes=10)
+                recent_signals = session.execute(
+                    select(Signal)
+                    .where(Signal.symbol == symbol)
+                    .where(Signal.timestamp >= lookback_time)
+                    .order_by(Signal.timestamp.desc())
+                ).scalars().all()
 
-                is_buy = all(s.final_score > config.open_th for s in recent_signals)
-                is_sell = all(s.final_score < -config.open_th for s in recent_signals)
+                if len(recent_signals) < config.entry_confirm_count:
+                    continue
 
-                if is_buy or is_sell:
-                    side = "BUY" if is_buy else "SELL"
-                    print(f"🚀 거래 신호 포착 (Lvl:{current_aggr_level}): {symbol} {side}")
+                entry_signals = recent_signals[:config.entry_confirm_count]
+                scores = [s.final_score for s in entry_signals]
 
-                    leverage = position_sizer.get_leverage_for_symbol(symbol, current_aggr_level)
-                    entry_atr = confluence_engine.extract_atr(tf_rows, primary_tf='4h') # 4시간봉 ATR을 기준으로
-                    quantity = position_sizer.calculate_position_size(symbol, entry_atr, current_aggr_level)
+                is_buy_base = all(score > config.open_threshold for score in scores)
+                is_sell_base = all(score < -config.open_threshold for score in scores)
 
-                    if quantity and quantity > 0:
-                        final_signal = recent_signals[0]
-                        analysis_context = {
-                            "symbol": symbol, "final_score": final_signal.final_score,
-                            "score_1d": final_signal.score_1d, "score_4h": final_signal.score_4h,
-                            "score_1h": final_signal.score_1h, "score_15m": final_signal.score_15m,
-                            "atr_1d": final_signal.atr_1d
-                        }
-                        await trading_engine.place_order(symbol, side, quantity, leverage, entry_atr, analysis_context)
-                        return
+                if not is_buy_base and not is_sell_base:
+                    continue
+
+                avg_score = sum(scores) / len(scores)
+                std_series = pd.Series(scores).std()
+                std_dev = float(std_series) if not pd.isna(std_series) else 0.0
+                is_momentum_positive = scores[0] > scores[-1] if is_buy_base else scores[0] < scores[-1]
+
+                print(
+                    f"[{symbol}] 신호 품질 평가: Avg={avg_score:.2f}, StdDev={std_dev:.2f}, "
+                    f"Momentum={'OK' if is_momentum_positive else 'Not Good'}"
+                )
+
+                is_quality_buy = (
+                    is_buy_base and
+                    avg_score >= config.quality_min_avg_score and
+                    std_dev <= config.quality_max_std_dev and
+                    is_momentum_positive
+                )
+
+                is_quality_sell = (
+                    is_sell_base and
+                    abs(avg_score) >= config.quality_min_avg_score and
+                    std_dev <= config.quality_max_std_dev and
+                    is_momentum_positive
+                )
+
+                if not (is_quality_buy or is_quality_sell):
+                    continue
+
+                side = "BUY" if is_quality_buy else "SELL"
+                print(f"🚀 고품질 거래 신호 포착!: {symbol} {side}")
+
+                final_signal = entry_signals[0]
+                atr_source = {}
+                if final_signal.atr_1d is not None:
+                    atr_source["1d"] = {"ATR_14": final_signal.atr_1d}
+                atr = confluence_engine.extract_atr(atr_source, primary_tf="1d") if atr_source else 0.0
+
+                if not atr or atr <= 0:
+                    print(f"[{symbol}] ATR 값이 유효하지 않아 주문을 실행할 수 없습니다.")
+                    continue
+
+                quantity = position_sizer.calculate_position_size(symbol, current_aggr_level, atr)
+                if not quantity or quantity <= 0:
+                    continue
+
+                leverage = position_sizer.get_leverage_for_symbol(symbol, current_aggr_level)
+                analysis_context = {
+                    "symbol": symbol,
+                    "side": side,
+                    "final_score": final_signal.final_score,
+                    "tf_scores": {
+                        "1d": final_signal.score_1d,
+                        "4h": final_signal.score_4h,
+                        "1h": final_signal.score_1h,
+                        "15m": final_signal.score_15m,
+                    },
+                    "entry_atr": atr,
+                    "signal_id": final_signal.id,
+                    "leverage": leverage,
+                }
+                await trading_engine.place_order(symbol, side, quantity, analysis_context)
+                return
     finally:
         session.close()
 

--- a/risk_management/position_sizer.py
+++ b/risk_management/position_sizer.py
@@ -28,7 +28,7 @@ class PositionSizer:
         else: # 8 to 10
             return symbol_leverage_map["HIGH"]
 
-    def calculate_position_size(self, symbol: str, atr: float, aggr_level: int) -> Optional[float]:
+    def calculate_position_size(self, symbol: str, aggr_level: int, atr: float) -> Optional[float]:
         account_balance = self._get_usdt_balance()
         if account_balance <= 0 or atr <= 0:
             print(f"계산 불가: 잔고({account_balance}) 또는 ATR({atr})이 유효하지 않습니다.")


### PR DESCRIPTION
## Summary
- add configurable signal quality thresholds and trailing stop flag to the config manager
- extend the Trade model and trading engine to capture highest price since entry and reuse existing signals when creating trades
- upgrade the trading decision loop with signal quality evaluation, ATR-based sizing, and trailing stop management

## Testing
- python -m compileall core database execution main.py risk_management

------
https://chatgpt.com/codex/tasks/task_e_68ddcf1ecc80832da62b6de4f1e0bc62