### PR TITLE
Implement market regime analysis and portfolio sizing

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -22,17 +22,26 @@ class ConfigManager:
             self.api_secret = os.getenv("BINANCE_LIVE_API_SECRET")
 
         # Analysis Engine
-        self.timeframes = self._get_list("ANALYSIS_TIMEFRAMES", ["15m", "1h", "4h", "1d"])
-        self.tf_vote_weights = self._get_list_float("TF_VOTE_WEIGHTS", [1.0, 2.0, 3.0, 4.0])
-        self.open_threshold = self._get_float("OPEN_TH", 10.0)
+        self.analysis_timeframes = self._get_list("ANALYSIS_TIMEFRAMES", ["1d", "4h", "1h", "15m"])
+        self.tf_vote_weights = self._get_list_float("TF_VOTE_WEIGHTS", [4.0, 3.0, 2.0, 1.0])
+        self.open_th = self._get_float("OPEN_TH", 12.0)
+        self.market_regime_adx_th = self._get_float("MARKET_REGIME_ADX_TH", 23.0)
+        # 하위 호환성 유지
+        self.timeframes = self.analysis_timeframes
+        self.open_threshold = self.open_th
 
         # Signal Quality Rules
         self.quality_min_avg_score = self._get_float("QUALITY_MIN_AVG_SCORE", 15.0)
         self.quality_max_std_dev = self._get_float("QUALITY_MAX_STD_DEV", 3.0)
 
         # Trading Logic Rules
-        self.entry_confirm_count = self._get_int("ENTRY_CONFIRM_COUNT", 3)
+        self.trend_entry_confirm_count = self._get_int("TREND_ENTRY_CONFIRM_COUNT", 3)
+        self.sideways_rsi_confirm_count = self._get_int("SIDEWAYS_RSI_CONFIRM_COUNT", 2)
+        self.sideways_rsi_oversold = self._get_float("SIDEWAYS_RSI_OVERSOLD", 35.0)
+        self.sideways_rsi_overbought = self._get_float("SIDEWAYS_RSI_OVERBOUGHT", 65.0)
         self.reversal_confirm_count = self._get_int("REVERSAL_CONFIRM_COUNT", 2)
+        # 하위 호환성 유지
+        self.entry_confirm_count = self.trend_entry_confirm_count
         
         # Risk Management
         self.aggr_level = self._get_int("AGGR_LEVEL", 3)
@@ -58,6 +67,9 @@ class ConfigManager:
         # Adaptive Logic
         self.adaptive_aggr_enabled = self._get_bool("ADAPTIVE_AGGR_ENABLED", True)
         self.adaptive_volatility_threshold = self._get_float("ADAPTIVE_VOLATILITY_THRESHOLD", 0.04)
+
+        # Portfolio Management
+        self.max_open_positions = self._get_int("MAX_OPEN_POSITIONS", 1)
 
         # Infrastructure
         self.db_path = os.getenv("DB_PATH", "./runtime/trader.db")

--- a/database/models.py
+++ b/database/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, String
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, String
 from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
@@ -16,6 +16,10 @@ class Signal(Base):
     score_15m = Column(Float)
     # 1일봉 ATR 값을 저장하여 변동성 분석에 사용
     atr_1d = Column(Float)
+    # 4시간봉 ADX 값을 저장하여 추세/횡보 판단에 사용
+    adx_4h = Column(Float)
+    # 1일봉 200 이평선 위에 있는지 여부 (장기 추세 판단)
+    is_above_ema200_1d = Column(Boolean)
     trade = relationship("Trade", back_populates="signal", uselist=False)
 
 class Trade(Base):

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from binance.client import Client
 from binance.exceptions import BinanceAPIException
 import asyncio
 from datetime import datetime, timezone, timedelta
+from enum import Enum
 from sqlalchemy import select
 import pandas as pd
 
@@ -40,6 +41,12 @@ position_sizer = PositionSizer(binance_client)
 # analyzer = PerformanceAnalyzer()
 
 # 4. 전역 변수
+
+class MarketRegime(Enum):
+    BULL_TREND = "강세 추세"
+    BEAR_TREND = "약세 추세"
+    SIDEWAYS = "횡보"
+
 current_aggr_level = config.aggr_level
 
 # --- 백그라운드 작업 (V3) ---
@@ -53,14 +60,26 @@ async def data_collector_loop():
             final_score, tf_scores, tf_rows = confluence_engine.analyze(symbol)
             if not tf_rows: continue
             
-            # 1일봉 ATR 추출
+            # 1일봉 ATR 추출 및 추가 지표 저장
             atr_1d_val = confluence_engine.extract_atr(tf_rows, primary_tf='1d')
+            adx_4h_val = None
+            is_above_ema200 = None
+
+            four_hour_row = tf_rows.get("4h")
+            if isinstance(four_hour_row, pd.Series):
+                adx_4h_val = four_hour_row.get("adx_value")
+
+            daily_row = tf_rows.get("1d")
+            if isinstance(daily_row, pd.Series):
+                is_above_ema200 = daily_row.get("is_above_ema200")
 
             new_signal = Signal(
                 symbol=symbol, final_score=final_score,
                 score_1d=tf_scores.get("1d"), score_4h=tf_scores.get("4h"),
                 score_1h=tf_scores.get("1h"), score_15m=tf_scores.get("15m"),
-                atr_1d=atr_1d_val
+                atr_1d=atr_1d_val,
+                adx_4h=adx_4h_val,
+                is_above_ema200_1d=is_above_ema200
             )
             session.add(new_signal)
         session.commit()
@@ -69,6 +88,28 @@ async def data_collector_loop():
         session.rollback()
     finally:
         session.close()
+
+def diagnose_market_regime(session, symbol: str) -> MarketRegime:
+    """최근 신호를 기반으로 시장 체제를 추정한다."""
+    latest_signal = (
+        session.execute(
+            select(Signal).where(Signal.symbol == symbol).order_by(Signal.id.desc())
+        ).scalar_one_or_none()
+    )
+
+    if (
+        not latest_signal
+        or latest_signal.adx_4h is None
+        or latest_signal.is_above_ema200_1d is None
+    ):
+        return MarketRegime.SIDEWAYS
+
+    adx_value = latest_signal.adx_4h
+    is_above_ema = bool(latest_signal.is_above_ema200_1d)
+
+    if adx_value > config.market_regime_adx_th:
+        return MarketRegime.BULL_TREND if is_above_ema else MarketRegime.BEAR_TREND
+    return MarketRegime.SIDEWAYS
 
 def update_adaptive_aggression_level():
     global current_aggr_level
@@ -99,7 +140,8 @@ def update_adaptive_aggression_level():
 
 @tasks.loop(minutes=5)
 async def trading_decision_loop():
-    if not config.exec_active: return
+    if not config.exec_active:
+        return
 
     if config.adaptive_aggr_enabled:
         update_adaptive_aggression_level()
@@ -107,132 +149,240 @@ async def trading_decision_loop():
     print(f"\n--- [Trading Decision (Lvl:{current_aggr_level})] 매매 결정 시작 ---")
     session = db_manager.get_session()
     try:
-        open_trade = session.execute(select(Trade).where(Trade.status == "OPEN")).scalar_one_or_none()
+        open_trades = (
+            session.execute(select(Trade).where(Trade.status == "OPEN")).scalars().all()
+        )
+        open_positions_count = len(open_trades)
 
-        if open_trade:
-            # --- B. 포지션이 있을 경우 (청산 결정) ---
-            print(f"오픈된 포지션 관리 중: {open_trade.symbol} {open_trade.side}")
-            current_price_info = binance_client.futures_mark_price(symbol=open_trade.symbol)
-            current_price = float(current_price_info['markPrice'])
+        if open_positions_count > 0:
+            print(f"총 {open_positions_count}개의 오픈된 포지션 관리 중...")
+            for trade in list(open_trades):
+                try:
+                    current_price_info = binance_client.futures_mark_price(symbol=trade.symbol)
+                    current_price = float(current_price_info["markPrice"])
+                except Exception as price_err:
+                    print(f"가격 조회 실패({trade.symbol}): {price_err}")
+                    continue
 
-            # 1. 진입 후 최고가/최저가 업데이트
-            if config.trailing_stop_enabled and open_trade.entry_atr:
-                if open_trade.side == "BUY" and (open_trade.highest_price_since_entry is None or current_price > open_trade.highest_price_since_entry):
-                    open_trade.highest_price_since_entry = current_price
-                    session.commit()
-                    print(f"📈 최고가 갱신: ${current_price}")
-                elif open_trade.side == "SELL" and (open_trade.highest_price_since_entry is None or current_price < open_trade.highest_price_since_entry):
-                    open_trade.highest_price_since_entry = current_price
-                    session.commit()
-                    print(f"📉 최저가 갱신: ${current_price}")
+                if config.trailing_stop_enabled and trade.entry_atr:
+                    if trade.side == "BUY":
+                        if (
+                            trade.highest_price_since_entry is None
+                            or current_price > trade.highest_price_since_entry
+                        ):
+                            trade.highest_price_since_entry = current_price
+                            session.commit()
+                            print(f"📈 최고가 갱신: ${current_price}")
+                        trailing_stop_price = (
+                            trade.highest_price_since_entry
+                            - (trade.entry_atr * config.sl_atr_multiplier)
+                        )
+                        if current_price < trailing_stop_price:
+                            await trading_engine.close_position(
+                                trade, f"트레일링 스탑 (TS: ${trailing_stop_price:.2f})"
+                            )
+                            open_positions_count = max(0, open_positions_count - 1)
+                            continue
+                    else:
+                        if (
+                            trade.highest_price_since_entry is None
+                            or current_price < trade.highest_price_since_entry
+                        ):
+                            trade.highest_price_since_entry = current_price
+                            session.commit()
+                            print(f"📉 최저가 갱신: ${current_price}")
+                        trailing_stop_price = (
+                            trade.highest_price_since_entry
+                            + (trade.entry_atr * config.sl_atr_multiplier)
+                        )
+                        if current_price > trailing_stop_price:
+                            await trading_engine.close_position(
+                                trade, f"트레일링 스탑 (TS: ${trailing_stop_price:.2f})"
+                            )
+                            open_positions_count = max(0, open_positions_count - 1)
+                            continue
 
-                # 2. 동적 트레일링 스탑 라인 계산
-                if open_trade.side == "BUY":
-                    trailing_stop_price = open_trade.highest_price_since_entry - (open_trade.entry_atr * config.sl_atr_multiplier)
-                    if current_price < trailing_stop_price:
-                        await trading_engine.close_position(open_trade, f"트레일링 스탑 (TS: ${trailing_stop_price:.2f})")
-                        return
-                else:
-                    trailing_stop_price = open_trade.highest_price_since_entry + (open_trade.entry_atr * config.sl_atr_multiplier)
-                    if current_price > trailing_stop_price:
-                        await trading_engine.close_position(open_trade, f"트레일링 스탑 (TS: ${trailing_stop_price:.2f})")
-                        return
+                pnl_pct = (
+                    (current_price - trade.entry_price) / trade.entry_price
+                    if trade.side == "BUY"
+                    else (trade.entry_price - current_price) / trade.entry_price
+                )
+                if pnl_pct >= config.take_profit_pct:
+                    await trading_engine.close_position(
+                        trade, f"수익 실현 ({pnl_pct:+.2%})"
+                    )
+                    open_positions_count = max(0, open_positions_count - 1)
 
-            # 보조적 익절 로직 유지
-            pnl_pct = (current_price - open_trade.entry_price) / open_trade.entry_price if open_trade.side == "BUY" else (open_trade.entry_price - current_price) / open_trade.entry_price
-            if pnl_pct >= config.take_profit_pct:
-                await trading_engine.close_position(open_trade, f"수익 실현 ({pnl_pct:+.2%})")
-                return
+        if open_positions_count < config.max_open_positions:
+            print(
+                f"신규 진입 기회 탐색 중... (현재 {open_positions_count}/{config.max_open_positions} 슬롯 사용 중)"
+            )
 
-            # ... (추세 반전 로직은 기존과 동일)
+            symbols_in_trade = {t.symbol for t in open_trades}
+            symbols_to_scan = [s for s in config.symbols if s not in symbols_in_trade]
 
+            for symbol in symbols_to_scan:
+                market_regime = diagnose_market_regime(session, symbol)
+                print(f"[{symbol}] 현재 시장 체제: {market_regime.value}")
+
+                if market_regime in (MarketRegime.BULL_TREND, MarketRegime.BEAR_TREND):
+                    recent_signals = (
+                        session.execute(
+                            select(Signal)
+                            .where(Signal.symbol == symbol)
+                            .order_by(Signal.timestamp.desc())
+                            .limit(config.trend_entry_confirm_count)
+                        ).scalars().all()
+                    )
+
+                    if len(recent_signals) < config.trend_entry_confirm_count:
+                        continue
+
+                    entry_signals = recent_signals
+                    scores = [s.final_score for s in entry_signals]
+
+                    is_buy_base = all(score > config.open_th for score in scores)
+                    is_sell_base = all(score < -config.open_th for score in scores)
+
+                    if not is_buy_base and not is_sell_base:
+                        continue
+
+                    std_series = pd.Series(scores).std() if len(scores) > 1 else 0.0
+                    std_dev = float(std_series) if not pd.isna(std_series) else 0.0
+                    avg_score = sum(scores) / len(scores)
+                    is_momentum_positive = (
+                        scores[0] > scores[-1] if len(scores) > 1 else True
+                    )
+
+                    print(
+                        f"[{symbol}] 추세 신호 평가: Avg={avg_score:.2f}, StdDev={std_dev:.2f}, "
+                        f"Momentum={'OK' if is_momentum_positive else 'Not Good'}"
+                    )
+
+                    is_quality_buy = (
+                        market_regime == MarketRegime.BULL_TREND
+                        and is_buy_base
+                        and avg_score >= config.quality_min_avg_score
+                        and std_dev <= config.quality_max_std_dev
+                        and is_momentum_positive
+                    )
+
+                    is_quality_sell = (
+                        market_regime == MarketRegime.BEAR_TREND
+                        and is_sell_base
+                        and abs(avg_score) >= config.quality_min_avg_score
+                        and std_dev <= config.quality_max_std_dev
+                        and is_momentum_positive
+                    )
+
+                    if not (is_quality_buy or is_quality_sell):
+                        continue
+
+                    side = "BUY" if is_quality_buy else "SELL"
+                    final_signal = entry_signals[0]
+                    entry_atr = final_signal.atr_1d or 0.0
+
+                    if entry_atr <= 0:
+                        print(f"[{symbol}] ATR 값이 유효하지 않아 주문을 실행할 수 없습니다.")
+                        continue
+
+                    quantity = position_sizer.calculate_position_size(
+                        symbol, entry_atr, current_aggr_level, open_positions_count
+                    )
+                    if not quantity or quantity <= 0:
+                        continue
+
+                    leverage = position_sizer.get_leverage_for_symbol(
+                        symbol, current_aggr_level
+                    )
+                    analysis_context = {
+                        "symbol": symbol,
+                        "side": side,
+                        "final_score": final_signal.final_score,
+                        "tf_scores": {
+                            "1d": final_signal.score_1d,
+                            "4h": final_signal.score_4h,
+                            "1h": final_signal.score_1h,
+                            "15m": final_signal.score_15m,
+                        },
+                        "entry_atr": entry_atr,
+                        "signal_id": final_signal.id,
+                        "leverage": leverage,
+                        "market_regime": market_regime.value,
+                    }
+                    await trading_engine.place_order(symbol, side, quantity, analysis_context)
+                    return
+
+                if market_regime == MarketRegime.SIDEWAYS:
+                    recent_signals = (
+                        session.execute(
+                            select(Signal)
+                            .where(Signal.symbol == symbol)
+                            .order_by(Signal.timestamp.desc())
+                            .limit(config.sideways_rsi_confirm_count)
+                        ).scalars().all()
+                    )
+
+                    if len(recent_signals) < config.sideways_rsi_confirm_count:
+                        continue
+
+                    entry_signals = recent_signals
+                    is_oversold = all(-5 < s.final_score < 0 for s in entry_signals)
+                    is_overbought = all(0 < s.final_score < 5 for s in entry_signals)
+
+                    if not is_oversold and not is_overbought:
+                        continue
+
+                    side = "BUY" if is_oversold else "SELL"
+                    final_signal = entry_signals[0]
+                    entry_atr = final_signal.atr_1d or 0.0
+
+                    if entry_atr <= 0:
+                        print(f"[{symbol}] ATR 값이 유효하지 않아 주문을 실행할 수 없습니다.")
+                        continue
+
+                    quantity = position_sizer.calculate_position_size(
+                        symbol, entry_atr, current_aggr_level, open_positions_count
+                    )
+                    if not quantity or quantity <= 0:
+                        continue
+
+                    leverage = position_sizer.get_leverage_for_symbol(
+                        symbol, current_aggr_level
+                    )
+                    analysis_context = {
+                        "symbol": symbol,
+                        "side": side,
+                        "final_score": final_signal.final_score,
+                        "tf_scores": {
+                            "1d": final_signal.score_1d,
+                            "4h": final_signal.score_4h,
+                            "1h": final_signal.score_1h,
+                            "15m": final_signal.score_15m,
+                        },
+                        "entry_atr": entry_atr,
+                        "signal_id": final_signal.id,
+                        "leverage": leverage,
+                        "market_regime": market_regime.value,
+                    }
+
+                    if is_oversold:
+                        print(f"횡보장 저점 포착! [평균 회귀 매수]: {symbol}")
+                    else:
+                        print(f"횡보장 고점 포착! [평균 회귀 매도]: {symbol}")
+
+                    await trading_engine.place_order(symbol, side, quantity, analysis_context)
+                    return
         else:
-            # --- A. 포지션이 없을 경우 (신규 진입 결정) ---
-            print("신규 진입 기회 탐색 중...")
-            for symbol in config.symbols:
-                lookback_time = datetime.utcnow() - timedelta(minutes=10)
-                recent_signals = session.execute(
-                    select(Signal)
-                    .where(Signal.symbol == symbol)
-                    .where(Signal.timestamp >= lookback_time)
-                    .order_by(Signal.timestamp.desc())
-                ).scalars().all()
+            print(
+                f"최대 포지션 개수({config.max_open_positions})에 도달하여 신규 진입을 탐색하지 않습니다."
+            )
 
-                if len(recent_signals) < config.entry_confirm_count:
-                    continue
-
-                entry_signals = recent_signals[:config.entry_confirm_count]
-                scores = [s.final_score for s in entry_signals]
-
-                is_buy_base = all(score > config.open_threshold for score in scores)
-                is_sell_base = all(score < -config.open_threshold for score in scores)
-
-                if not is_buy_base and not is_sell_base:
-                    continue
-
-                avg_score = sum(scores) / len(scores)
-                std_series = pd.Series(scores).std()
-                std_dev = float(std_series) if not pd.isna(std_series) else 0.0
-                is_momentum_positive = scores[0] > scores[-1] if is_buy_base else scores[0] < scores[-1]
-
-                print(
-                    f"[{symbol}] 신호 품질 평가: Avg={avg_score:.2f}, StdDev={std_dev:.2f}, "
-                    f"Momentum={'OK' if is_momentum_positive else 'Not Good'}"
-                )
-
-                is_quality_buy = (
-                    is_buy_base and
-                    avg_score >= config.quality_min_avg_score and
-                    std_dev <= config.quality_max_std_dev and
-                    is_momentum_positive
-                )
-
-                is_quality_sell = (
-                    is_sell_base and
-                    abs(avg_score) >= config.quality_min_avg_score and
-                    std_dev <= config.quality_max_std_dev and
-                    is_momentum_positive
-                )
-
-                if not (is_quality_buy or is_quality_sell):
-                    continue
-
-                side = "BUY" if is_quality_buy else "SELL"
-                print(f"🚀 고품질 거래 신호 포착!: {symbol} {side}")
-
-                final_signal = entry_signals[0]
-                atr_source = {}
-                if final_signal.atr_1d is not None:
-                    atr_source["1d"] = {"ATR_14": final_signal.atr_1d}
-                atr = confluence_engine.extract_atr(atr_source, primary_tf="1d") if atr_source else 0.0
-
-                if not atr or atr <= 0:
-                    print(f"[{symbol}] ATR 값이 유효하지 않아 주문을 실행할 수 없습니다.")
-                    continue
-
-                quantity = position_sizer.calculate_position_size(symbol, current_aggr_level, atr)
-                if not quantity or quantity <= 0:
-                    continue
-
-                leverage = position_sizer.get_leverage_for_symbol(symbol, current_aggr_level)
-                analysis_context = {
-                    "symbol": symbol,
-                    "side": side,
-                    "final_score": final_signal.final_score,
-                    "tf_scores": {
-                        "1d": final_signal.score_1d,
-                        "4h": final_signal.score_4h,
-                        "1h": final_signal.score_1h,
-                        "15m": final_signal.score_15m,
-                    },
-                    "entry_atr": atr,
-                    "signal_id": final_signal.id,
-                    "leverage": leverage,
-                }
-                await trading_engine.place_order(symbol, side, quantity, analysis_context)
-                return
+    except Exception as e:
+        print(f"🚨 매매 결정 중 오류: {e}")
     finally:
         session.close()
+
 
 
 # --- 봇 준비 및 실행 ---

--- a/risk_management/position_sizer.py
+++ b/risk_management/position_sizer.py
@@ -28,15 +28,27 @@ class PositionSizer:
         else: # 8 to 10
             return symbol_leverage_map["HIGH"]
 
-    def calculate_position_size(self, symbol: str, aggr_level: int, atr: float) -> Optional[float]:
+    def calculate_position_size(
+        self, symbol: str, atr: float, aggr_level: int, open_positions_count: int
+    ) -> Optional[float]:
         account_balance = self._get_usdt_balance()
         if account_balance <= 0 or atr <= 0:
             print(f"계산 불가: 잔고({account_balance}) 또는 ATR({atr})이 유효하지 않습니다.")
             return None
 
+        available_slots = config.max_open_positions - open_positions_count
+        if available_slots <= 0:
+            print("계산 불가: 더 이상 신규 포지션을 진입할 수 없습니다.")
+            return None
+
+        capital_to_use = account_balance / available_slots
+        print(
+            f"자본 배분: 총 잔고 ${account_balance:,.2f} -> 할당 자본 ${capital_to_use:,.2f} (슬롯 {available_slots}개 남음)"
+        )
+
         risk_multiplier = 1 + ((aggr_level - 5) / 10.0) # Level 5=1.0x, 1=0.6x, 10=1.5x
         dynamic_risk_pct = config.risk_target_pct * risk_multiplier
-        max_risk_per_trade = account_balance * dynamic_risk_pct
+        max_risk_per_trade = capital_to_use * dynamic_risk_pct
         
         stop_loss_distance = atr * config.sl_atr_multiplier
         if stop_loss_distance <= 0:
@@ -54,7 +66,9 @@ class PositionSizer:
                     if rounded_quantity <= 0:
                         print("계산 불가: 반올림된 수량이 0 이하입니다.")
                         return None
-                    print(f"동적 수량 계산(Lvl:{aggr_level}): 리스크=${max_risk_per_trade:,.2f} -> 수량={rounded_quantity}")
+                    print(
+                        f"동적 수량 계산(Lvl:{aggr_level}): 할당 자본 리스크=${max_risk_per_trade:,.2f} -> 수량={rounded_quantity}"
+                    )
                     return rounded_quantity
         except Exception as e:
             print(f"수량 정밀도 조회 실패: {e}")


### PR DESCRIPTION
## Summary
- extend the signal model and configuration loader with new market regime and portfolio settings
- expose ADX/EMA regime metadata from the confluence engine and persist it through the data collection flow
- redesign the trading loop to react to diagnosed regimes and allocate capital per remaining portfolio slots

## Testing
- python -m compileall database/models.py core/config_manager.py analysis/confluence_engine.py risk_management/position_sizer.py main.py

------
https://chatgpt.com/codex/tasks/task_e_68ddd12c1c28832d910b0e5f6cf3e4d2