### PR TITLE
Add interactive Discord control panel

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -74,6 +74,11 @@ class ConfigManager:
         # Infrastructure
         self.db_path = os.getenv("DB_PATH", "./runtime/trader.db")
         self.discord_bot_token = os.getenv("DISCORD_BOT_TOKEN") # Discord 토큰 추가
+        # Discord Channel IDs
+        self.dashboard_channel_id = self._get_int("DISCORD_CHANNEL_ID_DASHBOARD")
+        self.alerts_channel_id = self._get_int("DISCORD_CHANNEL_ID_ALERTS")
+        self.analysis_channel_id = self._get_int("DISCORD_CHANNEL_ID_ANALYSIS")
+        self.panel_channel_id = self._get_int("DISCORD_CHANNEL_ID_PANEL")
 
     def _get_bool(self, key: str, default: bool = False) -> bool:
         val = os.getenv(key)


### PR DESCRIPTION
## Summary
- align the configuration manager with the existing DISCORD_CHANNEL_ID_* environment variables
- rebuild the Discord control panel view with adaptive controls and aggression level callback support
- add the Korean `/패널` command, periodic panel refresh loop, and slash command sync on bot startup

## Testing
- python -m compileall core/config_manager.py ui/views.py main.py

------
https://chatgpt.com/codex/tasks/task_e_68ddd691e808832db0ff679f18929146