### PR TITLE
Add V4 bracket order handling and adaptive position sizing

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -31,12 +31,19 @@ class Trade(Base):
     side = Column(String)
     quantity = Column(Float)
     entry_price = Column(Float)
+    
+    # --- ▼▼▼ V4 수정 사항 ▼▼▼ ---
+    # 진입 시점의 ATR 값을 저장하여 기술적 손절 라인 계산에 사용
+    entry_atr = Column(Float)
+    # 진입 시점에 계산된 고정 손절/익절 가격 (브라켓 주문)
+    stop_loss_price = Column(Float)
+    take_profit_price = Column(Float)
+    # --- ▲▲▲ V4 수정 사항 ▲▲▲ ---
+
     highest_price_since_entry = Column(Float)
     exit_price = Column(Float)
     pnl = Column(Float)
     entry_time = Column(DateTime, default=datetime.utcnow)
     exit_time = Column(DateTime)
     status = Column(String, default="OPEN")
-    # 진입 시점의 ATR 값을 저장하여 기술적 손절 라인 계산에 사용
-    entry_atr = Column(Float)
     signal = relationship("Signal", back_populates="trade")

--- a/risk_management/position_sizer.py
+++ b/risk_management/position_sizer.py
@@ -3,6 +3,7 @@ from binance.client import Client
 from binance.exceptions import BinanceAPIException
 from core.config_manager import config
 
+
 class PositionSizer:
     def __init__(self, client: Client):
         self.client = client
@@ -25,12 +26,13 @@ class PositionSizer:
             return symbol_leverage_map["LOW"]
         elif 5 <= aggr_level <= 7:
             return symbol_leverage_map["MID"]
-        else: # 8 to 10
+        else:
             return symbol_leverage_map["HIGH"]
 
     def calculate_position_size(
-        self, symbol: str, atr: float, aggr_level: int, open_positions_count: int
+        self, symbol: str, atr: float, aggr_level: int, open_positions_count: int, average_score: float
     ) -> Optional[float]:
+        """[V4] 신호 등급과 포트폴리오를 고려하여 동적 포지션 크기를 계산합니다."""
         account_balance = self._get_usdt_balance()
         if account_balance <= 0 or atr <= 0:
             print(f"계산 불가: 잔고({account_balance}) 또는 ATR({atr})이 유효하지 않습니다.")
@@ -38,23 +40,29 @@ class PositionSizer:
 
         available_slots = config.max_open_positions - open_positions_count
         if available_slots <= 0:
-            print("계산 불가: 더 이상 신규 포지션을 진입할 수 없습니다.")
             return None
-
         capital_to_use = account_balance / available_slots
-        print(
-            f"자본 배분: 총 잔고 ${account_balance:,.2f} -> 할당 자본 ${capital_to_use:,.2f} (슬롯 {available_slots}개 남음)"
-        )
 
-        risk_multiplier = 1 + ((aggr_level - 5) / 10.0) # Level 5=1.0x, 1=0.6x, 10=1.5x
-        dynamic_risk_pct = config.risk_target_pct * risk_multiplier
-        max_risk_per_trade = capital_to_use * dynamic_risk_pct
-        
+        # --- ▼▼▼ V4 핵심 로직: 신호 등급별 리스크 스케일 적용 ▼▼▼ ---
+        abs_avg_score = abs(average_score)
+        if abs_avg_score >= 18.0:
+            risk_scale = config.risk_scale_high
+            grade = "A"
+        elif abs_avg_score >= 15.0:
+            risk_scale = config.risk_scale_medium
+            grade = "B"
+        else:
+            risk_scale = config.risk_scale_low
+            grade = "C"
+
+        risk_multiplier = 1 + ((aggr_level - 5) / 10.0)
+        final_risk_pct = config.risk_target_pct * risk_scale * risk_multiplier
+        max_risk_per_trade = capital_to_use * final_risk_pct
+        # --- ▲▲▲ V4 핵심 로직 ▲▲▲ ---
+
         stop_loss_distance = atr * config.sl_atr_multiplier
         if stop_loss_distance <= 0:
-            print("계산 불가: 손절 거리가 0 이하입니다.")
             return None
-            
         quantity = max_risk_per_trade / stop_loss_distance
 
         try:
@@ -64,14 +72,13 @@ class PositionSizer:
                     precision = s['quantityPrecision']
                     rounded_quantity = round(quantity, precision)
                     if rounded_quantity <= 0:
-                        print("계산 불가: 반올림된 수량이 0 이하입니다.")
                         return None
                     print(
-                        f"동적 수량 계산(Lvl:{aggr_level}): 할당 자본 리스크=${max_risk_per_trade:,.2f} -> 수량={rounded_quantity}"
+                        f"동적 수량 계산(Lvl:{aggr_level}, 등급:{grade}): "
+                        f"리스크 ${max_risk_per_trade:,.2f} -> 수량 {rounded_quantity}"
                     )
                     return rounded_quantity
         except Exception as e:
             print(f"수량 정밀도 조회 실패: {e}")
             return None
-        
         return None


### PR DESCRIPTION
## Summary
- add fields to persist entry ATR as well as calculated stop-loss and take-profit levels for each trade
- implement bracket order placement and full close-position handling in the trading engine
- scale position sizing by signal quality and update the trading loop to manage bracket exits and new entries

## Testing
- python -m compileall database execution risk_management main.py

------
https://chatgpt.com/codex/tasks/task_e_68dddc840f7c832da4ea5463a8b1b559